### PR TITLE
[8.0] Remove LcgFileCatalogClient

### DIFF
--- a/.github/workflows/basic-python3.yml
+++ b/.github/workflows/basic-python3.yml
@@ -1,0 +1,48 @@
+name: Python 3 tests
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
+    timeout-minutes: 30
+    defaults:
+      # Activate the conda environment automatically in each step
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: False
+      matrix:
+        command:
+          # TODO These three tests fail on Python 3:
+          #   * `test_BaseType_Unicode` and `test_nestedStructure` fail due to
+          #     DISET's string and unicode types being poorly defined
+          - pytest --runslow -k 'not test_BaseType_Unicode and not test_nestedStructure'
+          - find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
+          - pylint -E src/
+          - |
+            if [[ "${REFERENCE_BRANCH}" != "" ]]; then
+                git remote add upstream https://github.com/DIRACGrid/DIRAC.git
+                git fetch --no-tags upstream "${REFERENCE_BRANCH}"
+                git branch -vv
+                git diff -U0 "upstream/${REFERENCE_BRANCH}" ':(exclude)tests/formatting/pep8_bad.py' | pycodestyle --diff
+            fi
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
+    - uses: conda-incubator/setup-miniconda@master
+      with:
+        environment-file: environment-py3.yml
+        miniforge-variant: Mambaforge
+        use-mamba: true
+    - name: Run tests
+      run: |
+        # FIXME: The unit tests currently only work with editable installs
+        pip install -e .[server,testing]
+        ${{ matrix.command }}
+      env:
+        REFERENCE_BRANCH: ${{ github['base_ref'] || github['head_ref'] }}

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -7,42 +7,33 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
     timeout-minutes: 30
-    defaults:
-      # Activate the conda environment automatically in each step
-      run:
-        shell: bash -l {0}
 
     strategy:
       fail-fast: False
       matrix:
         command:
-          # TODO These three tests fail on Python 3:
-          #   * `test_BaseType_Unicode` and `test_nestedStructure` fail due to
-          #     DISET's string and unicode types being poorly defined
-          - pytest --runslow -k 'not test_BaseType_Unicode and not test_nestedStructure'
-          - find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
-          - pylint -E src/
-          - |
-            if [[ "${REFERENCE_BRANCH}" != "" ]]; then
-                git remote add upstream https://github.com/DIRACGrid/DIRAC.git
-                git fetch --no-tags upstream "${REFERENCE_BRANCH}"
-                git branch -vv
-                git diff -U0 "upstream/${REFERENCE_BRANCH}" ':(exclude)tests/formatting/pep8_bad.py' | pycodestyle --diff
-            fi
+          - pytest --runslow
+          # TODO This should cover more than just tests/CI
+          # Excluded codes related to sourcing files
+          #     SC1090: Can't follow non-constant source
+          #     SC1091: Not following sourced file
+          - tests/runPylint.sh
+          - tests/py3Check.sh
+          - CHECK=pylintPY3K tests/runPylint.sh
 
     steps:
     - uses: actions/checkout@v2
     - name: Fail-fast for outdated pipelines
       run: .github/workflows/fail-fast.sh
-    - uses: conda-incubator/setup-miniconda@master
-      with:
-        environment-file: environment.yml
-        miniforge-variant: Mambaforge
-        use-mamba: true
+    - name: Prepare environment
+      run: |
+        conda env create --name dirac-testing environment.yml
     - name: Run tests
       run: |
-        # FIXME: The unit tests currently only work with editable installs
-        pip install -e .[server,testing]
+        source "${CONDA}/bin/activate"
+        conda activate dirac-testing
+        set -euxo pipefail
+        export PYTHONPATH=${PWD}/src
         ${{ matrix.command }}
       env:
         REFERENCE_BRANCH: ${{ github['base_ref'] || github['head_ref'] }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,22 +1,12 @@
 name: Deployment
 
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
-    inputs:
-      check-ci:
-        description: "Require the CI to have passed for this commit"
-        required: true
-        default: "yes"
-      version:
-        description: "Override the release version number (e.g. 8.0.0a5)"
+on: [push, pull_request]
 
 jobs:
   deploy-pypi:
     name: PyPI deployment
     runs-on: "ubuntu-latest"
-    if: github.event_name != 'push' || github.repository == 'chrisburr/DIRAC-testing'
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
     defaults:
       run:
         shell: bash -l {0}
@@ -24,91 +14,42 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
-          git config --global user.email "ci@diracgrid.org"
-          git config --global user.name "DIRACGrid CI"
-      - uses: actions/setup-python@v2
+      # Use the action from conda-incubator to set up conda based on the
+      # conda-forge installer. Mamba is used to make the creation of the
+      # conda environment considerably faster.
+      - uses: conda-incubator/setup-miniconda@master
         with:
-          python-version: '3.9'
-      - name: Installing dependencies
-        run: |
-          python -m pip install \
-              build \
-              python-dateutil \
-              pytz \
-              readme_renderer \
-              requests \
-              setuptools_scm \
-              six
+          environment-file: environment-py3.yml
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - name: Validate README for PyPI
         run: |
           python -m readme_renderer README.rst -o /tmp/README.html
-      - name: Prepare release notes
-        run: |
-          set -xeuo pipefail
-          IFS=$'\n\t'
-          PREV_VERSION=$(git describe --tags --abbrev=0 --match '*[0-9].[0-9]*' --exclude 'v[0-9]r*' --exclude 'v[0-9][0-9]r*')
-          REFERENCE_BRANCH=${GITHUB_REF#refs/heads/}
-          echo "Making release notes for ${REFERENCE_BRANCH} since ${PREV_VERSION}"
-          ./docs/diracdoctools/scripts/dirac-docs-get-release-notes.py \
-              --token "${{ secrets.GITHUB_TOKEN }}" \
-              --sinceTag "${PREV_VERSION}" \
-              --branches "${REFERENCE_BRANCH}" \
-              > release.notes.new
-          cat release.notes.new
-      - name: Create tag if required
+      - name: Check tag is for v7r2 or later
         id: check-tag
+        # When v8 is released we can remove this check
         run: |
-          set -xeuo pipefail
-          IFS=$'\n\t'
-          if [[ "${{ github.repository }}" == "chrisburr/DIRAC-testing" ]]; then
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-              if [[ "${{ github.event.ref }}" =~ ^refs/heads/(new-deployment|rel-v([8-9]|[1-9][0-9]+)\.[0-9]+)$ ]]; then
-                echo "Will create a real release"
-                export NEW_VERSION="v${{ github.event.inputs.version }}"
-                if [[ "${NEW_VERSION}" == "v" ]]; then
-                  NEW_VERSION=v$(python -m setuptools_scm | sed 's@Guessed Version @@g' | sed -E 's@(\.dev|\+g).+@@g')
-                  export NEW_VERSION
-                fi
-                echo "Release will be named $NEW_VERSION"
-                # Validate the version
-                python -c $'from packaging.version import Version; v = Version('"'$NEW_VERSION'"$')\nif v.is_devrelease:\n    raise ValueError(v)'
-                # Commit the release notes
-                mv release.notes release.notes.old
-                {
-                  echo -e "[${NEW_VERSION}]" && \
-                  tail -n +2 release.notes.new | perl -0777pe 's/\n+$/\n\n/' && \
-                  cat release.notes.old;
-                } > release.notes
-                git add release.notes
-                git commit -m "docs: Add release notes for $NEW_VERSION"
-                git show
-                # Create the tag
-                git tag "$NEW_VERSION"
-                echo ::set-output name=create-release::true
-                echo ::set-output name=new-version::"$NEW_VERSION"
-              fi
-            fi
+          if [[ "${{ github.event.ref }}" =~ ^refs/tags/v7r([2-9]|[0-9][0-9]+)(p[0-9]+)?(-pre[0-9]+)?$ ]]; then
+              echo ::set-output name=create-release::true
           fi
+      - name: Make PEP-440 style release on GitHub
+        if: steps.check-tag.outputs.create-release == 'true'
+        run: |
+          OLD_STYLE=${GITHUB_REF##*/}
+          NEW_STYLE=$(python -c "import diraccfg; major, minor, patch, pre = diraccfg.parseVersion('${OLD_STYLE}'); print(f'{major}.{minor}.{patch}', f'a{pre}' if pre else '', sep='')")
+          echo "Converted ${OLD_STYLE} version to ${NEW_STYLE}"
+          .github/workflows/make_release.py \
+            --token="${{ secrets.GITHUB_TOKEN }}" \
+            --version="v${NEW_STYLE}" \
+            --rev="$(git rev-parse HEAD)"
+          git fetch --all --tags
+      # Need to do this after creating the PEP-440 style tag
       - name: Build distributions
         run: |
-          python -m build
-      - name: Make release on GitHub
-        if: steps.check-tag.outputs.create-release == 'true'
-        run: |
-          export NEW_VERSION=${{ steps.check-tag.outputs.new-version }}
-          echo "Making GitHub release for ${NEW_VERSION}"
-          git push "origin" "${GITHUB_REF#refs/heads/}"
-          .github/workflows/make_release.py \
-            --repo="${{ github.repository }}" \
-            --token="${{ secrets.GITHUB_TOKEN }}" \
-            --version="${NEW_VERSION}" \
-            --rev="$(git rev-parse HEAD)" \
-            --release-notes-fn="release.notes.new"
+          python setup.py sdist bdist_wheel
       - name: Publish package on PyPI
         if: steps.check-tag.outputs.create-release == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          # password: ${{ secrets.PYPI_API_TOKEN }}
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/diracinstall.yml
+++ b/.github/workflows/diracinstall.yml
@@ -1,0 +1,30 @@
+name: dirac-install
+
+on: [push, pull_request]
+
+jobs:
+  diracInstall:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
+
+    strategy:
+      fail-fast: False
+      matrix:
+        python:
+          - 2.7.5
+          - 2.7.13
+          - 3.6.8
+          - 3.9.4
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
+    - name: prepare environment
+      run: |
+        conda config --set add_pip_as_python_dependency false
+        conda create -c conda-forge -c free -n python_${{ matrix.python }} python=${{ matrix.python }}
+    - name: run dirac-install
+      run: |
+        eval "$(conda shell.bash hook)" && conda activate python_${{ matrix.python }}
+        python Core/scripts/dirac-install.py -l DIRAC -r integration -t server --dirac-os -ddd

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,20 +18,28 @@ jobs:
         include:
           ###### MySQL versions
           - TEST_NAME: "MySQL 5.7"
-            ARGS: MYSQL_VER=mysql:5.7
+            ARGS: CLIENT_USE_PYTHON3=Yes MYSQL_VER=mysql:5.7
           - TEST_NAME: "MariaDB 10.6"
-            ARGS: MYSQL_VER=mariadb:10.6.3
+            ARGS: CLIENT_USE_PYTHON3=Yes MYSQL_VER=mariadb:10.6.3
           # ###### ES versions
           - TEST_NAME: "Elasticsearch 6.6.0"
-            ARGS: ES_VER=elasticsearch:6.6.0
+            ARGS: CLIENT_USE_PYTHON3=Yes ES_VER=elasticsearch:6.6.0
           - TEST_NAME: "OpenSearch 1.0.0"
-            ARGS: ES_VER=opensearchproject/opensearch:1.0.0
+            ARGS: CLIENT_USE_PYTHON3=Yes ES_VER=opensearchproject/opensearch:1.0.0
           ###### Fewer cfg locks
           - TEST_NAME: "Fewer cfg locks"
-            ARGS: DIRAC_FEWER_CFG_LOCKS=Yes
+            ARGS: CLIENT_USE_PYTHON3=Yes DIRAC_FEWER_CFG_LOCKS=Yes
           ###### HTTPS tests
           - TEST_NAME: "HTTPS"
-            ARGS: TEST_HTTPS=Yes
+            ARGS: CLIENT_USE_PYTHON3=Yes TEST_HTTPS=Yes
+          - TEST_NAME: "Py3 client, py3 server + HTTPS"
+            ARGS: CLIENT_USE_PYTHON3=Yes SERVER_USE_PYTHON3=Yes TEST_HTTPS=Yes
+          ###### Python 2
+          - TEST_NAME: "Py2 client, py3 server"
+            ARGS: SERVER_USE_PYTHON3=Yes
+          - TEST_NAME: "Py2 client, py2 server"
+          - TEST_NAME: "Py2 client, py3 server+HTTPS"
+            ARGS: SERVER_USE_PYTHON3=Yes TEST_HTTPS=Yes
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +49,7 @@ jobs:
         git fetch --prune --unshallow
     - uses: conda-incubator/setup-miniconda@master
       with:
-        environment-file: environment.yml
+        environment-file: environment-py3.yml
         miniforge-variant: Mambaforge
         use-mamba: true
     - name: Prepare environment

--- a/.github/workflows/make_release.py
+++ b/.github/workflows/make_release.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-from pathlib import Path
 
 from packaging.version import Version
 import requests
@@ -50,10 +49,10 @@ def make_release(version, commit_hash, release_notes=""):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--token", required=True)
-    parser.add_argument("--repo", default="DIRACGrid/DIRAC")
+    parser.add_argument("--owner", default="DIRACGrid")
+    parser.add_argument("--repo", default="DIRAC")
     parser.add_argument("--version", required=True)
     parser.add_argument("--rev", required=True)
-    parser.add_argument("--release-notes-fn", required=True)
     args = parser.parse_args()
 
     token = args.token
@@ -61,10 +60,9 @@ if __name__ == "__main__":
         "Accept": "application/vnd.github.v3+json",
         "Authorization": f"token {token}",
     }
-    api_root = f"https://api.github.com/repos/{args.repo}"
-    release_notes = Path(args.release_notes_fn).read_text()
+    api_root = f"https://api.github.com/repos/{args.owner}/{args.repo}"
 
     if not args.version.startswith("v"):
         raise ValueError('For consistency versions must start with "v"')
 
-    make_release(args.version, args.rev, release_notes=release_notes)
+    make_release(args.version, args.rev, release_notes="")

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ formats: []
 
 # Use the same conda environment as the CI for building the docs
 conda:
-  environment: environment.yml
+  environment: environment-py3.yml
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -150,7 +150,6 @@ class GithubInterface(object):
     self.branches = ['Integration', 'rel-v6r21']
     self.openPRs = False
     self.sinceLatestTag = False
-    self.sinceTag = None
     self.headerMessage = None
     self.footerMessage = None
     self.startDate = datetime.datetime.now() - datetime.timedelta(days=14)
@@ -255,9 +254,6 @@ class GithubInterface(object):
     parser.add_argument("--sinceLatestTag", action="store_true", dest="sinceLatestTag", default=self.sinceLatestTag,
                         help="get release notes since latest tag (incompatible with --date)")
 
-    parser.add_argument("--sinceTag", dest="sinceTag", default=self.sinceTag,
-                        help="get release notes since latest tag (incompatible with --date)")
-
     parser.add_argument("--headerMessage", action="store", default=self.headerMessage, dest="headerMessage",
                         help="Header message to add between the release name and the list of PR. If it is a path,\
                          read the content of the file")
@@ -310,11 +306,10 @@ class GithubInterface(object):
 
     # If the date parsed does not correspond to the default,
     # and latestTag is asked, we throw an error
-    if (bool(parsed.date != self.startDate) + bool(parsed.sinceLatestTag) + bool(parsed.sinceTag)) > 1:
-      raise RuntimeError("--sinceLatestTag, --date and --sinceTag are mutually exclusive")
+    if (parsed.date != self.startDate) and parsed.sinceLatestTag:
+      raise RuntimeError("--sinceLatestTag incompatible with --date")
 
     self.sinceLatestTag = parsed.sinceLatestTag
-    self.sinceTag = parsed.sinceTag
 
     if self.sinceLatestTag:
       log.info('Starting from the latest tag')
@@ -416,26 +411,22 @@ class GithubInterface(object):
 
     return prsToReturn
 
-  def getGitlabLatestTagDate(self, sinceTag):
+  def getGitlabLatestTagDate(self):
     """ Get the latest tag creation date from gitlab
 
-    :param str sinceTag: Use this tag as a reference instead of the latest
     :returns: date of the latest tag
     """
-    if sinceTag:
-      raise NotImplementedError()
     glURL = self._gitlab('repository/tags')
     allTags = req2Json(glURL)
     lastTag = max([tag['commit']['created_at'] for tag in allTags])
     return dateutil.parser.isoparse(lastTag)
 
-  def getGithubLatestTagDate(self, sinceTag):
+  def getGithubLatestTagDate(self):
     """ Get the latest tag creation date from gitlab
 
-    :warning: tags can only be sorted by name, so we assume that the tags are ordered version numbers
+      :warning: tags can only be sorted by name, so we assume that the tags are ordered version numbers
 
-    :param str sinceTag: Use this tag as a reference instead of the latest
-    :returns: date of the latest tag
+      :returns: date of the latest tag
     """
     log = LOGGER.getChild('getGithubLatestTagDate')
 
@@ -444,19 +435,11 @@ class GithubInterface(object):
     if isinstance(tags, dict) and 'Not Found' in tags.get('message'):
       raise RuntimeError("Package not found: %s" % str(self))
 
-    if sinceTag:
-      for tag in tags:
-        if tag['name'] == sinceTag:
-          latestTag = tag
-          break
-      else:
-        raise ValueError("Tag %s not found" % sinceTag)
-    else:
-      sortedTags = sorted(
-          tags,
-          key=lambda tag: LooseVersion(tag['name']),
-          reverse=True)
-      latestTag = sortedTags[0]
+    sortedTags = sorted(
+        tags,
+        key=lambda tag: LooseVersion(tag['name']),
+        reverse=True)
+    latestTag = sortedTags[0]
 
     log.info("Found latest tag %s", latestTag['name'])
 
@@ -506,11 +489,11 @@ class GithubInterface(object):
     log = LOGGER.getChild("getReleaseNotes")
 
     # Check the latest tag if need be
-    if self.sinceLatestTag or self.sinceTag:
+    if self.sinceLatestTag:
       if self.useGithub:
-        self.startDate = self.getGithubLatestTagDate(self.sinceTag)
+        self.startDate = self.getGithubLatestTagDate()
       else:
-        self.startDate = self.getGitlabLatestTagDate(self.sinceTag)
+        self.startDate = self.getGitlabLatestTagDate()
       log.info("Starting from date %s", self.startDate)
 
     if self.useGithub:

--- a/docs/source/AdministratorGuide/CommandReference/dirac-cert-convert.sh.rst
+++ b/docs/source/AdministratorGuide/CommandReference/dirac-cert-convert.sh.rst
@@ -1,0 +1,16 @@
+============================
+dirac-cert-convert.sh
+============================
+
+  From a p12 file, obtain the pem files with 
+  the right access rights. Needed to obain a proxy.
+  Creates the necessary directory, $HOME/.globus,
+  if needed. Backs-up old pem files if any are found. 
+
+Usage::
+
+     dirac-cert-convert.sh CERT_FILE_NAME
+
+Arguments::
+
+  CERT_FILE_NAME:       Path to the p12 file.

--- a/docs/source/AdministratorGuide/CommandReference/index.rst
+++ b/docs/source/AdministratorGuide/CommandReference/index.rst
@@ -1,0 +1,196 @@
+====================================
+Administrator Command Reference
+====================================
+
+In this subsection all the dirac-admin commands available are explained. You can 
+get up-to-date documentation by using the -h switch on any of them. The following command line 
+flags are common to all DIRAC scripts making use of the *parseCommandLine* method of the base *Script* class::
+
+      General options: 
+        -o:  --option=         : Option=value to add 
+        -s:  --section=        : Set base section for relative parsed options 
+        -c:  --cert=           : Use server certificate to connect to Core Services 
+        -d   --debug           : Set debug mode (-dd is extra debug) 
+        -h   --help            : Shows this help 
+
+General information:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-admin-service-ports
+    dirac-platform
+
+.. _registry_cmd:
+
+Managing Registry:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-admin-add-group
+    dirac-admin-add-host
+    dirac-admin-add-user
+    dirac-admin-add-shifter
+    dirac-admin-delete-user
+    dirac-admin-list-hosts
+    dirac-admin-list-users
+    dirac-admin-modify-user
+    dirac-admin-sync-users-from-file
+    dirac-admin-user-quota
+    dirac-admin-users-with-proxy
+    dirac-admin-voms-sync
+
+Managing Resources:
+
+.. toctree::
+    :maxdepth: 2   
+    
+    dirac-admin-add-site
+    dirac-admin-add-resources
+    dirac-admin-allow-se
+    dirac-admin-allow-site
+    dirac-admin-ban-se
+    dirac-admin-ban-site
+    dirac-admin-ce-info
+    dirac-admin-get-banned-sites
+    dirac-admin-get-site-mask
+    dirac-admin-set-site-protocols
+    dirac-admin-site-info
+    dirac-admin-site-mask-logging
+    
+Workload management commands:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-admin-get-job-pilot-output
+    dirac-admin-get-job-pilots
+    dirac-admin-get-pilot-info
+    dirac-admin-get-pilot-logging-info
+    dirac-admin-get-pilot-output
+    dirac-admin-kill-pilot
+    dirac-admin-pilot-summary
+    dirac-admin-pilot-logging-info
+    dirac-admin-reset-job
+    dirac-admin-show-task-queues
+    dirac-jobexec
+
+Transformation management commands:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-transformation-add-files
+    dirac-transformation-archive
+    dirac-transformation-clean
+    dirac-transformation-cli
+    dirac-transformation-get-files
+    dirac-transformation-recover-data
+    dirac-transformation-remove-output
+    dirac-transformation-replication
+    dirac-transformation-verify-outputdata
+
+Managing DIRAC installation:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-framework-ping-service
+    dirac-install-component
+    dirac-install-db
+    dirac-install-web-portal
+    dirac-install-tornado-service
+    dirac-install-extension
+    dirac-uninstall-component
+    dirac-restart-component
+    dirac-start-component
+    dirac-status-component
+    dirac-stop-component
+    dirac-monitoring-get-components-status
+    dirac-service
+    dirac-setup-site
+    dirac-configure
+    dirac-admin-get-CAs
+    dirac-info
+    dirac-version
+    dirac-admin-check-config-options
+    dirac-populate-component-db
+
+Managing DIRAC software:
+
+.. toctree::
+    :maxdepth: 2
+    
+    dirac-deploy-scripts
+    dirac-externals-requirements
+
+User convenience:
+
+.. toctree::
+    :maxdepth: 2
+    
+    dirac-accounting-decode-fileid
+    dirac-cert-convert.sh
+    dirac-myproxy-upload
+    dirac-utils-file-adler
+    dirac-utils-file-md5
+
+.. _proxymanager_cmd:
+
+ProxyManager management commands:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-proxy-info
+    dirac-proxy-init
+    dirac-proxy-destroy
+    dirac-admin-get-proxy
+    dirac-admin-proxy-upload
+    dirac-proxy-get-uploaded-info
+
+Other commands:
+
+.. toctree::
+    :maxdepth: 2
+
+    dirac-login
+    dirac-logout
+
+    dirac-admin-accounting-cli
+    
+    dirac-admin-sysadmin-cli
+    dirac-admin-update-instance
+    dirac-admin-update-pilot
+    dirac-admin-sync-pilot
+
+    dirac-admin-sort-cs-sites
+
+    dirac-configuration-cli
+    dirac-configuration-dump-local-cache
+    dirac-configuration-shell
+
+
+    dirac-repo-monitor
+
+    dirac-rss-list-status
+    dirac-rss-query-db
+    dirac-rss-query-dtcache
+    dirac-rss-set-status
+    dirac-rss-set-token
+    dirac-rss-sync
+
+    dirac-stager-monitor-file
+    dirac-stager-monitor-jobs
+    dirac-stager-monitor-request
+    dirac-stager-monitor-requests
+    dirac-stager-show-stats
+    dirac-stager-stage-files
+
+    install_site.sh
+    
+    dirac-agent
+    dirac-executor
+
+    dirac-sys-sendmail

--- a/docs/source/AdministratorGuide/CommandReference/install_site.sh.rst
+++ b/docs/source/AdministratorGuide/CommandReference/install_site.sh.rst
@@ -1,0 +1,16 @@
+======================
+install_site.sh
+======================
+
+Usage::
+
+  install_site.sh [Options] ... CFG_file
+
+Options::
+  -v, --version  for a specific version
+  -d, --debug    debug mode
+  -h, --help     print this
+
+  CFG_file - is the name of the installation configuration file which contains
+             all the instructions for the DIRAC installation. 
+             See DIRAC Administrator Guide for the details

--- a/docs/source/DeveloperGuide/DevelopmentEnvironment/DeveloperInstallation/editingCode.rst
+++ b/docs/source/DeveloperGuide/DevelopmentEnvironment/DeveloperInstallation/editingCode.rst
@@ -87,7 +87,7 @@ Assuming you have already cloned DIRAC, you can create an environment for DIRAC 
 .. code-block:: bash
     :linenos:
 
-    mamba env create --name dirac-development --file environment.yml
+    mamba env create --name dirac-development --file environment-py3.yml
 
 
 Whenever you open a new terminal you can then activate the development environment by running:

--- a/docs/source/DeveloperGuide/ReleaseProcedure/index.rst
+++ b/docs/source/DeveloperGuide/ReleaseProcedure/index.rst
@@ -16,9 +16,6 @@ developers to possibly spot evident problems. The PRs are also reviewed by autom
 After the review the *PR* can be merged using the *Github* tools.
 After that the remote release branch is in the state ready to be tagged with the new version.
 
-.. warning:: These instructions only apply from DIRAC 8.0 series onwards!
-   See the documentation for previous releases for details on how to make legacy style releases.
-
 Prerequisites
 =============
 
@@ -29,42 +26,237 @@ The release manager needs to:
 
 The release manager of DIRAC should:
 
-1. Verify if new version of DIRACOS2 is needed
-2. Verify the GitHub actions CI is passing
-3. Create the release using GitHub Actions
-4. Check the releases is on `PyPI <https://pypi.org/project/DIRAC/>`_ and make basic verifications
-5. Propagate to CVMFS
+0. Verify if new version of DIRACOS/2 is needed
+1. Create the release(s)
+2. make basic verifications
+3. deploy the py2 DIRAC tarballs
+4. verify that the py3 release is created, and is on `pypi <https://pypi.org/project/DIRAC/>`_
+5. propagate to CVMFS
 
-6. Verify if new version of DIRACOS/2 is needed
+0. Verify if new version of DIRACOS/2 is needed
 ===============================================
 
-Code in open Pull Requests might be dependent from a new version of `DIRACOS2 <https://github.com/DIRACGrid/DIRACOS2>`_.
-Do verify for that before proceeding.
+Code in open Pull Requests might be dependent from a new version of `DIRACOS <https://github.com/DIRACGrid/DIRACOS>`_
+(and/or `DIRACOS2 <https://github.com/DIRACGrid/DIRACOS2>`_). Do verify for that before proceeding.
 
 
-2. Verify the GitHub actions CI is passing
-==========================================
+1. Creating the release(s)
+==========================
 
-The README on GitHub should show the status of the CI pipelines for all active releases branches.
-This should have ran recently and be in a good state before proceeding.
+The procedure consists of several steps:
 
-3. Create the release using GitHub Actions
-==========================================
+- Merge *Pull Requests*
+- Propagate patches to downstream release
+- Make release notes
+- Tag *release* branches with release version tags
+- Update the state of *release* and *integration* branches in the central repository
+- Update DIRAC software project description
+- Build and upload release tar files
 
-The CI can be manually triggered to create a release by going to `here <https://github.com/DIRACGrid/DIRAC/actions/workflows/deployment.yml>`_.
-From here click "Run workflow" and choose which branch should be used for a release.
-By default the CI will bump the release on the smallest component, i.e. `8.0.0a7` becomes `8.0.0a8` and `8.1.24` becomes `8.1.25`.
-To make a new release series this can be overridden manually.
 
-Release notes are automatically generated from the recently merged PRs and committed before creating the tag.
 
-4. Checking releases
-====================
+Release notes
+`````````````
 
-The first thing to ensure is that the release appears on `PyPI <https://pypi.org/project/DIRAC/>`_.
-TODO: Make a script to performance sanity checks?
+Release notes are contained in the *release.notes* file. Each release version has a dedicated
+section in this file, for example::
 
-1. Propagating to CVMFS [INCOMPLETE]
+  [v7r2p8]
+  
+  *Configuration
+  CHANGE: Let update the config, even if the Pilot info is not in the CS
+
+The section title as taken into the square brackets. Change notes are collected per subsystem
+denoted by a name starting with \*. Each change record starts with one of the follow header
+words: FIX:, BUGFIX:, CHANGE:, NEW: for fixes, bug fixes, small changes and new features
+correspondingly.
+
+Release notes for the given branch should be made in this branch.
+
+The release notes for a given branch can be obtained with the
+*docs/Tools/GetReleaseNotes.py* script::
+
+  $ python docs/Tools/GetReleaseNotes.py --branches <branch> [<branch2>...] --date <dateTheLastTagWasMade> [--openPRs]
+
+
+Working with code and tags
+---------------------------
+
+For simplicity and reproducibility, you can start from a fresh copy in a clean directory.
+This means that, you may want to start by moving to a temporary directory and issue the following::
+
+  $ mkdir $(date +"20%y%m%d") && cd $(date +"20%y%m%d")
+
+which will create a clean directory with today's date. We then clone the DIRAC repository and rename the created "origin" remote in "release"::
+
+  $ git clone git@github.com:DIRACGrid/DIRAC.git
+  $ cd DIRAC
+  $ git remote rename origin release
+
+
+
+Propagating patches
+-------------------
+
+There are a few DIRAC extensions, e.g. WebAppDIRAC.
+The procedure described below applies to all of them.
+Make sure that you apply the procedure starting with the DIRAC extensions.
+
+In the DIRAC Development Model several release branches can coexist in production.
+This means that patches applied to older branches must be propagated to the newer
+release branches. This is done in the local Git repository of the release manager.
+Let's take an example of a patch created against *release* branch *rel-7r1* while
+the new release branch *rel-v7r2* is already in production. This can be accomplished
+by the following sequence of commands, which will bring all the changes from
+the central repository including all the *release* branches.
+We now create local branch from the the remote one containing the patch. Release notes
+must be updated to create a new section for the new patch release describing the
+new changes. Now we can make a local branch corresponding to a downstream branch
+and merge the commits from the patches::
+
+  $ git checkout -b rel-v7r1 release/rel-v7r1
+  $ vim release.notes
+
+We can now start merging PRs, directly from GitHub. At the same time we edit
+the release notes to reflect what has been merged (please see the note below about how to edit this file).
+Once finished, save the file. Then, modify the ``__init__.py`` files of the root directory and define the version also there.
+Then we commit the changes (those done to ``release.notes`` and ``__init__.py``) and update the current repository::
+
+  $ git commit -a  # this will commit the changes we made to the release notes in rel-v7r1 local branch
+  $ git fetch release  # this will bring in the updated release/rel-v7r1 branch from the github repository
+  $ git rebase --no-ff release/rel-v7r1  # this will rebase the current rel-v7r1 branch to the content of release/rel-v7r1
+
+You can now proceed with pushing, and check the tests::
+
+  $ git push release rel-v7r1  # we push to the rel-v7r1 branch too.
+
+From the previous command, note that due to the fact that we are pushing a branch named *rel-v7r1*
+to the *release* repository, where it already exists a branch named *rel-v7r1*,
+**the local branch will override the remote one**.
+
+Now, before performing any further step, you should go to `GitHub Actions (GA) <https://github.com/DIRACGrid/DIRAC/actions>`_
+and check the result of the workflows that are running on the pushed *rel-v7r1* branch.
+
+If everything is fine, you can tag::
+
+  $ git tag -a v7r1p37 -m "v7r1p37"  # this will create an annotated tag, from the current branch, in the local repository
+  $ git push release v7r1p37  # we push to the *release* repository (so to GitHub-hosted one) the tag just created
+
+All the patches must now be also propagated to the *upper* branches.
+In this example we are going through, we are supposing that it exists *rel-v7r2* branch,
+from which we already derived production tags. We then have to propagate the changes done to
+*rel-v7r1* to *rel-v7r2*. Note that if even the patch was made to an upstream release branch, the subsequent
+release branch must also receive a new patch release tag. Multiple patches can be
+add in one release operation.::
+
+  $ git checkout -b rel-v7r2 release/rel-v7r2
+  $ git merge release/rel-v7r1
+
+This may result in merge conflicts, which should be resolved "by hand".
+One typical conflict is about the content of the ``release.notes`` file.
+
+From now on, the process will look very similar to what we have already done for
+creating tag v7r1p37. We should then repeat the process for v7r2::
+
+  $ vim release.notes
+  $ vim __init__.py
+
+Merge PRs (if any), then save the files above. Then::
+
+  $ git commit -a  # this will commit the changes we made to the release notes in rel-v7r2 local branch
+  $ git fetch release  # this will bring in the updated release/rel-v7r2 branch from the github repository
+  $ git rebase --no-ff release/rel-v7r2  # this will rebase the current rel-v7r2 branch to the content of release/rel-v7r2
+  $ git push release rel-v7r2  # we push to the *release* remote the tag just created, and the rel-v7r2 branch.
+
+Now, check GA and if everything is fine::
+
+  $ git tag v7r2p8  # this will create a tag, from the current branch, in the local repository
+  $ git push v7r2p8  # we push to the *release* remote the tag just created
+
+The *master* branch of DIRAC always contains the latest stable release.
+If this corresponds to rel-v7r2, we should make sure that this is updated::
+
+  $ git push release rel-v7r2:master
+
+Repeat the process for every "upper" release branch.
+When the release branch of the latest stable version is changed, i.e. from rel-v7r2 to rel-v7r3, the URL of the CI status badge in the README should be edited.
+
+The *integration* branch is also receiving new features to go into the next release.
+The *integration* branch also contains the ``releases.cfg`` file, which holds all the versions of DIRAC
+together with the dependencies among the different packages. 
+
+From the *integration* branch we also do all the tags of *pre-release* versions, that can be then installed
+with standard tools on test DIRAC servers. 
+
+The procedure for creating pre-releases is very similar to creating releases::
+
+  $ vim release.notes
+  $ vim __init__.py
+  $ vim releases.cfg  # add the created tags (all of them, releases and pre-releases)
+
+Merge all the PRs targeting integration that have been approved (if any), then save the files above. Then::
+
+  $ git commit -a
+  $ git fetch release
+  $ git rebase --no-ff release/integration
+  $ git push release integration
+
+Wait for tests on GA to complete and then::
+
+  $ git tag v7r3-pre9
+  $ git push v7r3-pre9
+
+
+2. Making basic verifications
+=============================
+
+All unit and integration tests are automatically run by `GitHub Actions <https://github.com/DIRACGrid/DIRAC/actions>`_
+
+GitHub actions also runs on all the Pull Requests, so if for all the PRs merged GitHub Actions didn't show any problem,
+there's a good chance (but NOT the certainty) that the created tags are also sane.
+
+From version v7r2, python3 releases are automatically created (again, by GitHub Actions)
+when a tag is pushed, and should be found on `pypi <https://pypi.org/project/DIRAC/>`_.
+
+
+3. Deploying python2 DIRAC tarballs
+===================================
+
+Once the release and integration branches are tagged and pushed, the new release and pre-release versions are
+properly described in the ``release.cfg`` file in the *integration* branch and
+also pushed to the central repository, the tar archives containing the new
+codes can be created.
+
+For releasing python2 DIRAC, you need to be in an environment where
+*Sencha cmd* has been installed and *extjs* is downloaded.
+There's a Docker image that contains all the above dependencies.
+It can be found in GitHub package registry or in docker hub::
+
+  docker.pkg.github.com/diracgrid/management/dirac-distribution:latest (https://github.com/DIRACGrid/management/packages/79929)
+  diracgrid/dirac-distribution (https://hub.docker.com/r/diracgrid/dirac-distribution)
+
+The image is rebuilt once per week based on this `Dockerfile in <https://github.com/DIRACGrid/management/blob/master/dirac-distribution/Dockerfile>`_
+
+Pull it and run inside the dirac-distribution command::
+
+  $ docker pull diracgrid/dirac-distribution
+  $ python3 dirac-distribution.py -r v7r2p8
+
+The above works also for DIRAC extensions, in this case just remember to specify the project name, e.g.::
+
+  $ python3 dirac-distribution.py --release v10r2p11 --project LHCb
+
+You can also pass the releases.cfg to use via command line using the *-relcfg* switch.
+*dirac-distribution* will generate a set of tarballs, release notes in *html* and md5 files.
+
+In the end of its execution, the *dirac-distribution* will print out a command that can be
+used to upload generated release files to a predefined repository (see :ref:`dirac_projects`).
+
+You can then run this `Jenkins check <https://jenkins-dirac.web.cern.ch/view/DIRAC/job/Pilot3_CVM4_pipeline/>`_
+If it passes, it's time to advertise that new releases have been created. Use the DIRAC google forum.
+
+
+4. Propagating to CVMFS [INCOMPLETE]
 =====================================
 
 There's a Docker image that contains all the needed dependencies.

--- a/docs/source/UserGuide/CommandReference/Others/dirac-cert-convert.sh.rst
+++ b/docs/source/UserGuide/CommandReference/Others/dirac-cert-convert.sh.rst
@@ -1,0 +1,8 @@
+============================
+dirac-cert-convert.sh
+============================
+
+Usage::
+
+     dirac-cert-convert.sh CERT_FILE_NAME.p12
+

--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -6,28 +6,28 @@ channels:
   - defaults
 
 dependencies:
+  # Temporary workarounds
+  - astroid 2.5.6  # https://github.com/PyCQA/astroid/issues/1006 and https://github.com/PyCQA/astroid/issues/1007
   # runtime
-  - python =2.7
+  - python =3.9
   - pip
   - apache-libcloud
   - boto3
+  - cachetools
   - certifi
   - cmreshandler >1.0.0b4
-  - cachetools <4
   - docutils
   - elasticsearch <7.14
-  - elasticsearch-dsl ~=6.3.1
-  - fts-rest
+  - elasticsearch-dsl
+  - fts3
   - future
   - gitpython >=2.1.0
-  - ldap3
-  - m2crypto >=0.36
-  - matplotlib >=2.1.0,<3.0
-  - mysql-python
-  - numpy >=1.10.1,<1.16  # Limit to 1.15 as Python 2 pylint has bugs with numpy 1.16
+  - m2crypto >=0.36,!=0.38.0
+  - matplotlib
+  - numpy
   - pexpect >=4.0.1
   - pillow
-  - prompt_toolkit
+  - prompt-toolkit >=3,<4
   - psutil >=4.2.0
   - pyasn1 >0.4.1
   - pyasn1-modules
@@ -37,16 +37,25 @@ dependencies:
   - requests >=2.9.1
   - six >=1.10
   - sqlalchemy
-  - subprocess32
   - stomp.py =4.1.23
   - suds-jurko >=0.6
   - xmltodict
+  - pycurl
+  - voms
+  - python-gfal2
+  - mysqlclient
+  - diraccfg
+  - subprocess32
+  - ldap3
+  - importlib_resources
   # testing and development
   - autopep8
   - caniusepython3
   - coverage
+  - docker-compose
   - hypothesis
   - ipython
+  - make
   - mock
   - parameterized
   - pylint >=1.6.5
@@ -54,33 +63,41 @@ dependencies:
   - pytest >=3.6
   - pytest-cov >=2.2.0
   - pytest-mock
+  - setuptools-scm
   - shellcheck
+  - typer
+  - typer-cli
   - flaky
-  - importlib_resources
   # docs
   - pygments >=1.5
   - sphinx
+  - graphviz
+  # RTD Sphinx theme
+  - sphinx_rtd_theme
+  # Bootstrap and new elements fo Sphinx
+  - sphinx-panels
   # unused
   - funcsigs
-  - futures
   - jinja2
-  - multi-mechanize >=1.2.0
+  # PyPI deployment
+  - readme_renderer
+  - twine
+  - uritemplate
   # - readline >=6.2.4 in the standard library
   - simplejson >=3.8.1
   #- tornado >=5.0.0,<6.0.0
   - typing >=3.6.6
-  # Pin OpenSSL to avoid: https://github.com/DIRACGrid/DIRAC/issues/4489
-  - openssl <1.1
-  - selectors2
+  - pyyaml
   - pip:
-    - diraccfg
-    # OAuth2
+    # Prerelease of the required package for integration of OAuth2
+    - Authlib>=1.0.0.a2
     - dominate
-    - authlib
     - pyjwt
     # This is a fork of tornado with a patch to allow for configurable iostream
+    # It should eventually be part of DIRACGrid
     - git+https://github.com/DIRACGrid/tornado.git@iostreamConfigurable
     # This is an extension of Tornado to use M2Crypto
+    # It should eventually be part of DIRACGrid
     - git+https://github.com/DIRACGrid/tornado_m2crypto
-    - rucio-clients >= 1.25.6
-
+    - rucio-clients >=1.26.0rc1
+    - -e .

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -29,6 +29,7 @@ FEATURE_VARIABLES = {
     "DIRACOS_TARBALL_PATH": None,
     "TEST_HTTPS": "No",
     "DIRAC_FEWER_CFG_LOCKS": None,
+    "USE_PYTHON3": None,
 }
 DEFAULT_MODULES = {
     "DIRAC": Path(__file__).parent.absolute(),
@@ -269,11 +270,26 @@ def prepare_environment(
     for name, config in [("server", server_config), ("client", client_config)]:
         if path := config.get("DIRACOS_TARBALL_PATH"):
             path = Path(path)
-            config["DIRACOS_TARBALL_PATH"] = f"/{path.name}"
-            subprocess.run(
-                ["docker", "cp", str(path), f"{name}:/{config['DIRACOS_TARBALL_PATH']}"],
-                check=True,
-            )
+            if config["USE_PYTHON3"]:
+                config["DIRACOS_TARBALL_PATH"] = f"/{path.name}"
+                subprocess.run(
+                    ["docker", "cp", str(path), f"{name}:/{config['DIRACOS_TARBALL_PATH']}"],
+                    check=True,
+                )
+            else:
+                md5_fn = Path(str(path).replace(".tar.gz", ".md5"))
+                if not md5_fn.exists():
+                    typer.secho(
+                        "Failed to find MD5 filename for DIRACOS_TARBALL_PATH. "
+                        f"Expected at: {md5_fn}",
+                        err=True,
+                        fg=c.RED,
+                    )
+                    raise typer.Exit(1)
+                subprocess.run(["docker", "cp", str(path), f"{name}:/{path.name}"], check=True)
+                subprocess.run(["docker", "cp", str(md5_fn), f"{name}:/{md5_fn.name}"], check=True)
+                config["DIRACOS_TARBALL_PATH"] = "/"
+                config["DIRACOSVER"] = md5_fn.stem.split("-", 1)[1]
 
         config_as_shell = _dict_to_shell(config)
         typer.secho(f"## {name.title()} config is:", fg=c.BRIGHT_WHITE, bg=c.BLACK)
@@ -676,6 +692,10 @@ def _make_config(modules, flags, release_var, editable):
     config["ALTERNATIVE_MODULES"] = [
         f"/home/dirac/LocalRepo/ALTERNATIVE_MODULES/{name}" for name in modules
     ]
+    if not config["USE_PYTHON3"]:
+        config["ALTERNATIVE_MODULES"] = [
+            f"{x}/src/{Path(x).name}" for x in config["ALTERNATIVE_MODULES"]
+        ]
 
     # Exit with an error if there are unused feature flags remaining
     if flags:

--- a/release.notes
+++ b/release.notes
@@ -1,4 +1,3 @@
-[v7.4.0a2]
 [v7r4-pre1]
 
 NEW: Basic support for the OAuth/OIDC tokens

--- a/releases.cfg
+++ b/releases.cfg
@@ -26,12 +26,12 @@ Releases
   }
   v7r4-pre1
   {
-    Modules = DIRAC, RESTDIRAC:v0r5, COMDIRAC:v0r19, WebAppDIRAC:v4r4-pre1
+    Modules = DIRAC, RESTDIRAC:v0r5, COMDIRAC:v0r19, WebAppDIRAC:v4r3-pre16
     DIRACOS = v1r26
   }
   v7r3p1
   {
-    Modules = DIRAC, RESTDIRAC:v0r5, COMDIRAC:v0r19, WebAppDIRAC:v4r3
+    Modules = DIRAC, RESTDIRAC:v0r5, COMDIRAC:v0r19, WebAppDIRAC:v4r3-pre16
     DIRACOS = v1r26
   }
   v7r2p25

--- a/src/DIRAC/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyManagerClient.py
@@ -206,7 +206,7 @@ class ProxyManagerClient(object):
     # Make sure it's valid
     if chain.hasExpired().get('Value'):
       return S_ERROR("Proxy %s has expired" % proxyLocation)
-    if chain.getDIRACGroup(ignoreDefault=True).get('Value') or chain.isVOMS().get('Value'):
+    if chain.getDIRACGroup().get('Value') or chain.isVOMS().get('Value'):
       return S_ERROR("Cannot upload proxy with DIRAC group or VOMS extensions")
 
     rpcClient = RPCClient("Framework/ProxyManager", timeout=120)

--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -32,10 +32,6 @@
     - WorkloadManagement
 
     It defines the following data members:
-    - majorVersion:  DIRAC Major version number
-    - minorVersion:  DIRAC Minor version number
-    - patchLevel:    DIRAC Patch level number
-    - preVersion:    DIRAC Pre release number
     - version:       DIRAC version string
 
     - errorMail:     mail address for important errors

--- a/tests/CI/install_server.sh
+++ b/tests/CI/install_server.sh
@@ -90,8 +90,13 @@ then
   # system_component is a space separated System (without the word System), and Component, without the 'Handler.py'.
   # For example "DataManagement TornadoFileCatalog"
 
-  find "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC" -name 'Tornado*Handler.py' | grep -v Configuration | sed -e 's/Handler.py//g' -e 's/System//g'| awk -F '/' '{print $(NF-2), $NF}' > tornadoServices
-  cfgProdFile="${SERVERINSTALLDIR}"/diracos/etc/Production.cfg
+  if [[ "${USE_PYTHON3:-}" == "Yes" ]]; then
+    find "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC" -name 'Tornado*Handler.py' | grep -v Configuration | sed -e 's/Handler.py//g' -e 's/System//g'| awk -F '/' '{print $(NF-2), $NF}' > tornadoServices
+    cfgProdFile="${SERVERINSTALLDIR}"/diracos/etc/Production.cfg
+  else
+    find "${SERVERINSTALLDIR}"/DIRAC/ -name 'Tornado*Handler.py' | grep -v Configuration | sed -e 's/Handler.py//g' -e 's/System//g'| awk -F '/' '{print $(NF-2), $NF}' > tornadoServices
+    cfgProdFile="${SERVERINSTALLDIR}"/etc/Production.cfg
+  fi
 
   while read -r system_component; do
     echo -e "*** $(date -u) **** Installing Tornado service ${system_component}"

--- a/tests/Integration/WorkloadManagementSystem/pilot.cfg
+++ b/tests/Integration/WorkloadManagementSystem/pilot.cfg
@@ -1,0 +1,15 @@
+DIRAC
+{
+  Setup = dirac-JenkinsSetup
+}
+LocalSite
+{
+  ReleaseProject = LHCb
+  SharedArea = /cvmfs/lhcb.cern.ch/lib
+  GridMiddleware = DIRAC
+  Site = DIRAC.Jenkins.ch
+  GridCE = jenkins.cern.ch
+  CEQueue = jenkins-queue_not_important
+  Architecture = x86_64-slc6
+  CPUNormalizationFactor = 10.0
+}

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -116,30 +116,66 @@ installSite() {
 
   echo "==> Started installing"
 
-  cd "$SERVERINSTALLDIR"
-  if [[ -n "${DIRACOS_TARBALL_PATH:-}" ]]; then
-    cp "${DIRACOS_TARBALL_PATH}" "installer.sh"
-  else
-    if [[ -n "${DIRACOSVER:-}" ]] && [[ "${DIRACOSVER}" != "master" ]]; then
-      DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/download/${DIRACOSVER}/DIRACOS-Linux-x86_64.sh"
+  if [[ "${USE_PYTHON3:-}" == "Yes" ]]; then
+    cd "$SERVERINSTALLDIR"
+    if [[ -n "${DIRACOS_TARBALL_PATH:-}" ]]; then
+      cp "${DIRACOS_TARBALL_PATH}" "installer.sh"
     else
-      DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh"
+      if [[ -n "${DIRACOSVER:-}" ]] && [[ "${DIRACOSVER}" != "master" ]]; then
+        DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/download/${DIRACOSVER}/DIRACOS-Linux-x86_64.sh"
+      else
+        DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh"
+      fi
+      curl -L "${DIRACOS2_URL}" > "installer.sh"
     fi
-    curl -L "${DIRACOS2_URL}" > "installer.sh"
-  fi
-  bash "installer.sh"
-  rm "installer.sh"
-  echo "source \"$PWD/diracos/diracosrc\"" > "$PWD/bashrc"
-  # TODO: This will be fixed properly as part of https://github.com/DIRACGrid/DIRAC/issues/5082
-  mv "${SERVERINSTALLDIR}/etc/grid-security/"* "${SERVERINSTALLDIR}/diracos/etc/grid-security/"
-  rm -rf "${SERVERINSTALLDIR}/etc"
-  ln -s "${SERVERINSTALLDIR}/diracos/etc" "${SERVERINSTALLDIR}/etc"
-  source diracos/diracosrc
-  for module_path in "${ALTERNATIVE_MODULES[@]}"; do
-    pip install ${PIP_INSTALL_EXTRA_ARGS:-} "${module_path}[server]"
-  done
-  cd -
+    bash "installer.sh"
+    rm "installer.sh"
+    echo "source \"$PWD/diracos/diracosrc\"" > "$PWD/bashrc"
+    # TODO: This will be fixed properly as part of https://github.com/DIRACGrid/DIRAC/issues/5082
+    mv "${SERVERINSTALLDIR}/etc/grid-security/"* "${SERVERINSTALLDIR}/diracos/etc/grid-security/"
+    rm -rf "${SERVERINSTALLDIR}/etc"
+    ln -s "${SERVERINSTALLDIR}/diracos/etc" "${SERVERINSTALLDIR}/etc"
+    source diracos/diracosrc
+    for module_path in "${ALTERNATIVE_MODULES[@]}"; do
+      pip install ${PIP_INSTALL_EXTRA_ARGS:-} "${module_path}[server]"
+    done
+    cd -
+  else
+    prepareForServer
 
+    if [[ -n "${DEBUG+x}" ]]; then
+      INSTALLOPTIONS+=("${DEBUG}")
+    fi
+
+    if [[ "${DIRACOSVER}" ]]; then
+      INSTALLOPTIONS+=("--dirac-os")
+      INSTALLOPTIONS+=("--dirac-os-version=${DIRACOSVER}")
+    fi
+
+    if [[ "$DIRACOS_TARBALL_PATH" ]]; then
+      {
+        echo "DIRACOS = $DIRACOS_TARBALL_PATH"
+      } >> "${SERVERINSTALLDIR}/dirac-ci-install.cfg"
+    fi
+
+    if [[ -n "${ALTERNATIVE_MODULES+x}" ]]; then
+      echo "Installing from non-release code"
+      option="--module="
+      for module_path in "${ALTERNATIVE_MODULES[@]}"; do
+        if [[ -d "${module_path}" ]]; then
+          option+="${module_path}:::$(basename "${module_path}"):::local,"
+        else
+          option+="${module_path},"
+        fi
+      done
+      INSTALLOPTIONS+=("${option: :$((${#option} - 1))}")
+    fi
+
+    if ! "${SERVERINSTALLDIR}/dirac-install.py" "${INSTALLOPTIONS[@]}" "${SERVERINSTALLDIR}/install.cfg" "${SERVERINSTALLDIR}/dirac-ci-install.cfg"; then
+      echo "ERROR: dirac-install.py failed" >&2
+      exit 1
+    fi
+  fi
 
   echo "==> Done installing, now configuring"
   source "${SERVERINSTALLDIR}/bashrc"

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -313,31 +313,73 @@ installDIRAC() {
     exit 1
   fi
 
-  if [[ -n "${DIRACOS_TARBALL_PATH:-}" ]]; then
-    cp "${DIRACOS_TARBALL_PATH}" "installer.sh"
-  else
-    if [[ -n "${DIRACOSVER:-}" ]] && [[ "${DIRACOSVER}" != "master" ]]; then
-      DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/download/${DIRACOSVER}/DIRACOS-Linux-x86_64.sh"
+  if [[ "${USE_PYTHON3:-}" == "Yes" ]]; then
+    if [[ -n "${DIRACOS_TARBALL_PATH:-}" ]]; then
+      cp "${DIRACOS_TARBALL_PATH}" "installer.sh"
     else
-      DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh"
+      if [[ -n "${DIRACOSVER:-}" ]] && [[ "${DIRACOSVER}" != "master" ]]; then
+        DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/download/${DIRACOSVER}/DIRACOS-Linux-x86_64.sh"
+      else
+        DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh"
+      fi
+      curl -L "${DIRACOS2_URL}" > "installer.sh"
     fi
-    curl -L "${DIRACOS2_URL}" > "installer.sh"
-  fi
-  bash "installer.sh"
-  rm "installer.sh"
-  # TODO: Remove
-  echo "source \"$PWD/diracos/diracosrc\"" > "$PWD/bashrc"
-  echo "export X509_CERT_DIR=\"$PWD/diracos/etc/grid-security/certificates\"" >> "$PWD/bashrc"
-  source diracos/diracosrc
-  if [[ -n "${DIRAC_RELEASE+x}" ]]; then
-    if [[ -z "${ALTERNATIVE_MODULES}" ]]; then
-      pip install DIRAC "${DIRAC_RELEASE}"
+    bash "installer.sh"
+    rm "installer.sh"
+    # TODO: Remove
+    echo "source \"$PWD/diracos/diracosrc\"" > "$PWD/bashrc"
+    echo "export X509_CERT_DIR=\"$PWD/diracos/etc/grid-security/certificates\"" >> "$PWD/bashrc"
+    source diracos/diracosrc
+    if [[ -n "${DIRAC_RELEASE+x}" ]]; then
+      if [[ -z "${ALTERNATIVE_MODULES}" ]]; then
+        pip install DIRAC "${DIRAC_RELEASE}"
+      fi
     fi
-  fi
-  for module_path in "${ALTERNATIVE_MODULES[@]}"; do
-    pip install ${PIP_INSTALL_EXTRA_ARGS:-} "${module_path}"
-  done
+    for module_path in "${ALTERNATIVE_MODULES[@]}"; do
+      pip install ${PIP_INSTALL_EXTRA_ARGS:-} "${module_path}"
+    done
+  else
+    echo -n > "${CLIENTINSTALLDIR}/dirac-ci-install.cfg"
 
+    curl -L "https://raw.githubusercontent.com/DIRACGrid/management/master/dirac-install.py" \
+        > "${CLIENTINSTALLDIR}/dirac-install"
+    chmod +x "${CLIENTINSTALLDIR}/dirac-install"
+
+    if [[ -n "${DEBUG+x}" ]]; then
+      INSTALLOPTIONS+=("${DEBUG}")
+    fi
+
+    if [[ -n "${ALTERNATIVE_MODULES+x}" ]]; then
+      echo "Installing from non-release code"
+      local option="--module="
+      for module_path in "${ALTERNATIVE_MODULES[@]}"; do
+        if [[ -d "${module_path}" ]]; then
+          option+="${module_path}:::$(basename "${module_path}"):::local,"
+        else
+          option+="${module_path},"
+        fi
+      done
+      INSTALLOPTIONS+=("${option: :$((${#option} - 1))}")
+    fi
+
+    if [[ "${DIRACOSVER}" ]]; then
+      INSTALLOPTIONS+=("--dirac-os")
+      INSTALLOPTIONS+=("--dirac-os-version=${DIRACOSVER}")
+    fi
+
+    if [[ "$DIRACOS_TARBALL_PATH" ]]; then
+      {
+        echo "DIRACOS = $DIRACOS_TARBALL_PATH"
+      } >> "${CLIENTINSTALLDIR}/dirac-ci-install.cfg"
+    fi
+
+    if ! ./dirac-install -r "${DIRAC_RELEASE}" -t client "${INSTALLOPTIONS[@]}" "${CLIENTINSTALLDIR}/dirac-ci-install.cfg"; then
+      echo 'ERROR: DIRAC client installation failed' >&2
+      exit 1
+    fi
+
+    source bashrc
+  fi
   echo "$DIRAC"
   echo "$PATH"
 


### PR DESCRIPTION
The `lfcthr` Python module isn't included in DIRACOS2 but I don't think anyone is still using it so I guess this code can be simply removed?

BEGINRELEASENOTES

*DataManagement
CHANGE: The LcgFileCatalogClient has been removed

ENDRELEASENOTES
